### PR TITLE
Drop support for Go 1.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 go:
-  - 1.8.x
+  - 1.9.x
   - tip
 services:
   - docker


### PR DESCRIPTION
@rarguelloF I think you need that, as Vault doesn't build any more with Go 1.8